### PR TITLE
Fix grave stone NPE when writing to NBT

### DIFF
--- a/src/main/java/com/fireball1725/graves/tileentity/TileEntityGraveStone.java
+++ b/src/main/java/com/fireball1725/graves/tileentity/TileEntityGraveStone.java
@@ -83,9 +83,11 @@ public class TileEntityGraveStone extends TileEntityInventoryBase {
 
         nbtTagCompound.setBoolean("hasLid", this.hasLid);
 
-        NBTTagCompound profileTag = new NBTTagCompound();
-        NBTUtil.writeGameProfile(profileTag, playerProfile);
-        nbtTagCompound.setTag("playerProfile", profileTag);
+        if (playerProfile != null) {
+            NBTTagCompound profileTag = new NBTTagCompound();
+            NBTUtil.writeGameProfile(profileTag, playerProfile);
+            nbtTagCompound.setTag("playerProfile", profileTag);
+        }
     }
 
     public void breakBlocks() {


### PR DESCRIPTION
Fixes #12 

When upgrading Graves from a version where `playerProfile` didn't exist would mean that the saved `NBTTagCompound` didn't have the information necessary to create the `GameProfile` causing the field to be null, causing an NPE when the TE tried to write itself to NBT.
