### PR TITLE
Make the player zombie transparent

### DIFF
--- a/src/main/java/com/fireball1725/graves/client/render/entity/RenderPlayerZombie.java
+++ b/src/main/java/com/fireball1725/graves/client/render/entity/RenderPlayerZombie.java
@@ -14,6 +14,7 @@ import net.minecraft.client.renderer.entity.layers.LayerHeldItem;
 import net.minecraft.entity.boss.BossStatus;
 import net.minecraft.item.ItemBow;
 import net.minecraft.util.ResourceLocation;
+import org.lwjgl.opengl.GL11;
 
 public class RenderPlayerZombie extends RenderBiped<EntityPlayerZombie> {
     private static final ModelPlayer STEVE = new ModelPlayer(0, false);
@@ -60,6 +61,9 @@ public class RenderPlayerZombie extends RenderBiped<EntityPlayerZombie> {
     @Override
     protected void preRenderCallback(EntityPlayerZombie entity, float float0) {
         GlStateManager.scale(0.9375F, 0.9375F, 0.9375F);
+        GlStateManager.color(1, 1, 1, 0.75f);
+        GlStateManager.enableBlend();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
     }
 
     private void setModel(EntityPlayerZombie playerZombie) {


### PR DESCRIPTION
@FireBall1725, I figured it out! You needed to enable blending and call the blend function in addition to setting the color.

The player zombie now renders at 75% opacity:
![2016-01-26_13 29 42](https://cloud.githubusercontent.com/assets/7091588/12590511/5d6235d8-c431-11e5-8b3d-07099aa509e5.png)
